### PR TITLE
Define datetime predicates

### DIFF
--- a/dedupe/variables/datetime.py
+++ b/dedupe/variables/datetime.py
@@ -4,13 +4,21 @@ from dedupe.variables.string import affineGap
 from dedupe.variables.base import FieldType, DerivedType
 from dedupe import predicates
 from datetime_distance import DateTimeComparator
+import dedupe.variables.datetime_predicates as dtp
 import numpy as np
 
 
 class DateTimeType(FieldType):
 
     type = "DateTime"
-    _predicate_functions = [predicates.wholeFieldPredicate]
+    _predicate_functions = [predicates.wholeFieldPredicate,
+                            dtp.yearPredicate,
+                            dtp.monthPredicate,
+                            dtp.dayPredicate,
+                            dtp.hourPredicate,
+                            dtp.exclusiveMonthPredicate,
+                            dtp.exclusiveDayPredicate,
+                            dtp.exclusiveHourPredicate]
 
     def __len__(self):
 

--- a/dedupe/variables/datetime_predicates.py
+++ b/dedupe/variables/datetime_predicates.py
@@ -10,12 +10,29 @@ def parse_field(field):
     return dt
 
 
+def make_predicate(attrs):
+    """
+    Standardized helper function to handle missing resolutions and
+    return predicates.
+    """
+    output = tuple(attrs)
+    # Check that all resolutions are present in the string
+    if all(output):
+        return output
+    else:
+        return ()
+
+
 def yearPredicate(field):
     """
     Hash a field based on year.
     """
     dt = parse_field(field)
-    return (dt.year,)
+    # Parser will return a NoneType in case of a bad parse
+    if dt:
+        return make_predicate([dt.year])
+    else:
+        return ()
 
 
 def monthPredicate(field):
@@ -23,7 +40,10 @@ def monthPredicate(field):
     Hash a field based on year + month.
     """
     dt = parse_field(field)
-    return (dt.year, dt.month)
+    if dt:
+        return make_predicate([dt.year, dt.month])
+    else:
+        return ()
 
 
 def exclusiveMonthPredicate(field):
@@ -31,7 +51,10 @@ def exclusiveMonthPredicate(field):
     Hash a field based on calendar month (e.x. 'June').
     """
     dt = parse_field(field)
-    return (dt.month,)
+    if dt:
+        return make_predicate([dt.month])
+    else:
+        return ()
 
 
 def dayPredicate(field):
@@ -39,7 +62,10 @@ def dayPredicate(field):
     Hash a field based on year + month + day.
     """
     dt = parse_field(field)
-    return (dt.year, dt.month, dt.day)
+    if dt:
+        return make_predicate([dt.year, dt.month, dt.day])
+    else:
+        return ()
 
 
 def exclusiveDayPredicate(field):
@@ -47,7 +73,10 @@ def exclusiveDayPredicate(field):
     Hash a field based on calendar day (e.x. '23rd').
     """
     dt = parse_field(field)
-    return (dt.day,)
+    if dt:
+        return make_predicate([dt.day])
+    else:
+        return ()
 
 
 def hourPredicate(field):
@@ -55,7 +84,10 @@ def hourPredicate(field):
     Hash a field based on year + month + day + nearest hour.
     """
     dt = parse_field(field)
-    return (dt.year, dt.month, dt.day, dt.hour)
+    if dt:
+        return make_predicate([dt.year, dt.month, dt.day, dt.hour])
+    else:
+        return ()
 
 
 def exclusiveHourPredicate(field):
@@ -63,4 +95,7 @@ def exclusiveHourPredicate(field):
     Hash a field based on nearest hour (e.x. '5:00')
     """
     dt = parse_field(field)
-    return (dt.hour,)
+    if dt:
+        return make_predicate([dt.hour])
+    else:
+        return ()

--- a/dedupe/variables/datetime_predicates.py
+++ b/dedupe/variables/datetime_predicates.py
@@ -1,0 +1,66 @@
+from datetime_distance import DateTimeComparator
+
+
+def parse_field(field):
+    """
+    Standardized helper function to parse a datetime field.
+    """
+    comp = DateTimeComparator()
+    dt = comp.parse_resolution(field)[0]
+    return dt
+
+
+def yearPredicate(field):
+    """
+    Hash a field based on year.
+    """
+    dt = parse_field(field)
+    return (dt.year,)
+
+
+def monthPredicate(field):
+    """
+    Hash a field based on year + month.
+    """
+    dt = parse_field(field)
+    return (dt.year, dt.month)
+
+
+def exclusiveMonthPredicate(field):
+    """
+    Hash a field based on calendar month (e.x. 'June').
+    """
+    dt = parse_field(field)
+    return (dt.month,)
+
+
+def dayPredicate(field):
+    """
+    Hash a field based on year + month + day.
+    """
+    dt = parse_field(field)
+    return (dt.year, dt.month, dt.day)
+
+
+def exclusiveDayPredicate(field):
+    """
+    Hash a field based on calendar day (e.x. '23rd').
+    """
+    dt = parse_field(field)
+    return (dt.day,)
+
+
+def hourPredicate(field):
+    """
+    Hash a field based on year + month + day + nearest hour.
+    """
+    dt = parse_field(field)
+    return (dt.year, dt.month, dt.day, dt.hour)
+
+
+def exclusiveHourPredicate(field):
+    """
+    Hash a field based on nearest hour (e.x. '5:00')
+    """
+    dt = parse_field(field)
+    return (dt.hour,)

--- a/tests/test_datetime_comparator.py
+++ b/tests/test_datetime_comparator.py
@@ -83,32 +83,64 @@ def test_year_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.yearPredicate(field) == (2013,)
 
+    missing_field = '11:45am May 6th'
+    assert dtp.yearPredicate(missing_field) == ()
+
 
 def test_month_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.monthPredicate(field) == (2013, 5)
+
+    missing_field = '2013'
+    assert dtp.monthPredicate(missing_field) == ()
 
 
 def test_exclusive_month_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.exclusiveMonthPredicate(field) == (5,)
 
+    missing_field = '11:45am'
+    assert dtp.exclusiveMonthPredicate(missing_field) == ()
+
 
 def test_day_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.dayPredicate(field) == (2013, 5, 6)
+
+    missing_field = 'May 2013'
+    assert dtp.dayPredicate(missing_field) == ()
 
 
 def test_exclusive_day_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.exclusiveDayPredicate(field) == (6,)
 
+    missing_field = '5/2013'
+    assert dtp.exclusiveDayPredicate(missing_field) == ()
+
 
 def test_hour_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.hourPredicate(field) == (2013, 5, 6, 11)
 
+    missing_field = 'May 6th, 2013'
+    assert dtp.hourPredicate(missing_field) == ()
+
 
 def test_exclusive_hour_predicate():
     field = '11:45am May 6th, 2013'
     assert dtp.exclusiveHourPredicate(field) == (11,)
+
+    missing_field = 'May 6th, 2013'
+    assert dtp.exclusiveHourPredicate(missing_field) == ()
+
+
+def test_bad_parse_predicate():
+    field = 'foo bar'
+    assert dtp.yearPredicate(field) == ()
+    assert dtp.monthPredicate(field) == ()
+    assert dtp.exclusiveMonthPredicate(field) == ()
+    assert dtp.dayPredicate(field) == ()
+    assert dtp.exclusiveDayPredicate(field) == ()
+    assert dtp.hourPredicate(field) == ()
+    assert dtp.exclusiveHourPredicate(field) == ()

--- a/tests/test_datetime_comparator.py
+++ b/tests/test_datetime_comparator.py
@@ -3,6 +3,7 @@ import math
 import numpy as np
 
 from dedupe.variables.datetime import DateTimeType
+import dedupe.variables.datetime_predicates as dtp
 
 
 def test_datetime_to_datetime_comparison():
@@ -11,11 +12,13 @@ def test_datetime_to_datetime_comparison():
                                                 '2017-01-01'),
         np.array([1, 0, 1, 0, 0, 0, math.sqrt(144), 0, 0, 0]))
 
+
 def test_datetime_to_timestamp_comparison():
     dt = DateTimeType({'field': 'foo'})
     np.testing.assert_almost_equal(dt.comparator('2017-05-25',
                                                 '2017-01-01 12:30:05'),
         np.array([1, 0, 1, 0, 0, 0, math.sqrt(143), 0, 0, 0]))
+
 
 def test_timestamp_to_timestamp_comparison():
     dt = DateTimeType({'field': 'foo'})
@@ -23,11 +26,13 @@ def test_timestamp_to_timestamp_comparison():
                                                 '2017-01-01 12:30:05'),
         np.array([1, 1, 0, 0, 0, math.sqrt(12472684), 0, 0, 0, 0]))
 
+
 def test_years():
     dt = DateTimeType({'field': 'foo'})
     np.testing.assert_almost_equal(dt.comparator('2012',
                                                 '2010'),
         np.array([1, 0, 0, 0, 1, 0, 0, 0, math.sqrt(2), 0]))
+
 
 def test_months():
     dt = DateTimeType({'field': 'foo'})
@@ -35,11 +40,13 @@ def test_months():
                                                 'June 2013'),
         np.array([1, 0, 0, 1, 0, 0, 0, math.sqrt(13), 0, 0]))
 
+
 def test_days():
     dt = DateTimeType({'field': 'foo'})
     np.testing.assert_almost_equal(dt.comparator('5 May 2013',
                                                 '9 June 2013'),
         np.array([1, 0, 1, 0, 0, 0, math.sqrt(35), 0, 0, 0]))
+
 
 def test_alternate_formats():
     dt = DateTimeType({'field': 'foo'})
@@ -56,6 +63,7 @@ def test_alternate_formats():
                             dt.comparator('May 5th, 2013',
                                          '2013-06-09'))
 
+
 def test_bad_parse():
     dt = DateTimeType({'field': 'foo'})
     np.testing.assert_almost_equal(dt.comparator('foo',
@@ -64,7 +72,43 @@ def test_bad_parse():
 
     assert len(dt.comparator('foo', 'bar') == len(dt.higher_vars))
 
+
 def test_missing():
     dt = DateTimeType({'field': 'foo'})
     np.testing.assert_almost_equal(dt.comparator('', 'non-empty'),
                                    np.zeros(len(dt)))
+
+
+def test_year_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.yearPredicate(field) == (2013,)
+
+
+def test_month_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.monthPredicate(field) == (2013, 5)
+
+
+def test_exclusive_month_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.exclusiveMonthPredicate(field) == (5,)
+
+
+def test_day_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.dayPredicate(field) == (2013, 5, 6)
+
+
+def test_exclusive_day_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.exclusiveDayPredicate(field) == (6,)
+
+
+def test_hour_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.hourPredicate(field) == (2013, 5, 6, 11)
+
+
+def test_exclusive_hour_predicate():
+    field = '11:45am May 6th, 2013'
+    assert dtp.exclusiveHourPredicate(field) == (11,)


### PR DESCRIPTION
Implements a set of predicates for the DateTime field, including:

* Year
* Month
* Day
* Hour
* Month exclusive
* Day exclusive
* Hour exclusive

The expected behavior of these predicates are outlined in the new predicate tests in `tests/test_datetime_comparator.py`. In general, we return tuples with integer values for the given resolution, e.g. `monthPredicate('June 2nd 2017')` returns the tuple `(2017, 6)`.

Note that the parser will return an **empty string** for a given date resolution if that resolution is not present in the string (e.g. the parsed version of `'June 2nd 2017'` will have an `hour` value of `''`). This means that there can be **mixed types** in the returned tuples. If this is a problem, we can alter the behavior to return `NoneTypes` for absent resolutions, or we can universally return strings for date values instead of integers (e.g. `('2017', '6') rather than (2017, 6)`).