### PR TITLE
Handle dates where the year is missing

### DIFF
--- a/dedupe/variables/datetime_predicates.py
+++ b/dedupe/variables/datetime_predicates.py
@@ -78,7 +78,7 @@ def threeDayPredicate(field):
     """
     dt1 = parse_field(field)
     if dt1:
-        if dt1.day and dt1.year:
+        if dt1.year and dt1.month and dt1.day:
             dt_obj = datetime(dt1.year, dt1.month, dt1.day)
             dt0 = parse_field(str(dt_obj - timedelta(1)))
             dt2 = parse_field(str(dt_obj + timedelta(1)))

--- a/dedupe/variables/datetime_predicates.py
+++ b/dedupe/variables/datetime_predicates.py
@@ -78,7 +78,7 @@ def threeDayPredicate(field):
     """
     dt1 = parse_field(field)
     if dt1:
-        if dt1.day:
+        if dt1.day and dt1.year:
             dt_obj = datetime(dt1.year, dt1.month, dt1.day)
             dt0 = parse_field(str(dt_obj - timedelta(1)))
             dt2 = parse_field(str(dt_obj + timedelta(1)))

--- a/tests/test_datetime_comparator.py
+++ b/tests/test_datetime_comparator.py
@@ -49,6 +49,12 @@ def test_days():
         np.array([1, 0, 1, 0, 0, 0, math.sqrt(35), 0, 0, 0]))
 
 
+def test_month_and_day():
+    dt = DateTimeType({'field': 'foo'})
+    np.testing.assert_almost_equal(dt.comparator('7/7',
+                                                 'July 9th'),
+        np.array([1, 0, 1, 0, 0, 0, math.sqrt(2), 0, 0, 0]))
+
 def test_alternate_formats():
     dt = DateTimeType({'field': 'foo'})
     comp = dt.comparator('May 5th, 2013','2013-06-09')
@@ -146,12 +152,14 @@ def test_three_day_predicate():
     assert '2015-5-7' in dtp.threeDayPredicate(field)
     assert '2015-5-7' in dtp.threeDayPredicate(field2)
 
-    missing_field = 'May 2015'
-    assert dtp.threeDayPredicate(missing_field) == ()
+    missing_fields = ['May 2015', '5/13']
+    for missing_field in missing_fields:
+        assert dtp.threeDayPredicate(missing_field) == ()
 
     bad_parse_field = '2015-06-05 1899-12-30'
     expected = ('2015-6-4', '2015-6-5', '2015-6-6')
     assert dtp.threeDayPredicate(bad_parse_field) == expected
+
 
 def test_hour_predicate():
     field = '11:45am May 6th, 2013'


### PR DESCRIPTION
Closes #5. `threeDayPredicate` expects to have year, month, and day values, but we don't actually check whether the parsed date has all these values before trying to perform date algebra, resulting in errors in cases where the year is missing (like `7/7`). This PR adds the appropriate check, and includes a regression test for this case.